### PR TITLE
bundle exec fix

### DIFF
--- a/lib/guard/bundler.rb
+++ b/lib/guard/bundler.rb
@@ -4,12 +4,14 @@ require 'guard/guard'
 
 module Guard
   class Bundler < Guard
+    BUNDLER_ENV_VARS = %w(RUBYOPT BUNDLE_PATH BUNDLE_BIN_PATH BUNDLE_GEMFILE).freeze
 
     autoload :Notifier, 'guard/bundler/notifier'
 
     def initialize(watchers = [], options = {})
       super
 
+      @original_env = {}
       options[:notify] = true if options[:notify].nil?
     end
  
@@ -38,14 +40,38 @@ module Guard
     end
 
     def bundle_need_refresh?
-      `bundle check`
+      with_clean_env do
+        `bundle check`
+      end
       $? == 0 ? false : true
+    end
+
+    def with_clean_env
+      unset_bundler_env_vars
+      ENV['BUNDLE_GEMFILE'] = File.join(Dir.pwd, "Gemfile")
+      yield
+    ensure
+      restore_env
+    end
+
+    def unset_bundler_env_vars
+      BUNDLER_ENV_VARS.each do |key|
+        @original_env[key] = ENV[key]
+        ENV[key] = nil
+      end
+    end
+
+    def restore_env
+      @original_env.each { |key, value| ENV[key] = value }
     end
 
     def refresh_bundle
       UI.info 'Refresh bundle', :reset => true
       start_at = Time.now
-      result = system('bundle install')
+      result = ''
+      with_clean_env do
+        result = system('bundle install')
+      end
       Notifier::notify(true, Time.now - start_at) if notify?
       result
     end


### PR DESCRIPTION
I've implemented the fix [suggested by jferris](https://github.com/guard/guard-bundler/issues/2#issue/2/comment/779110).  I didn't modify the specs because 1) I'm not that familiar with RSpec's mocks and 2) I have limited time at the moment to figure out a good way to test the changes.  I know that might sound like a cop-out but unfortunately it's the truth right now.  If you require the specs to reflect the new changes before you will accept the pull request, it will be some time later before I can get to it.  I've tested the changes locally and it does in fact work.  Since this code is simply copied from jferris's example combined with the fact that I've verified that the code does work, it's relatively safe to assume the code is in good shape.
