### PR TITLE
Made notifications terms correct: It's bundle install, not update

### DIFF
--- a/lib/guard/bundler/notifier.rb
+++ b/lib/guard/bundler/notifier.rb
@@ -8,9 +8,9 @@ module Guard
         when 'up-to-date'
           "Bundle already up-to-date"
         when true
-          "Bundle has been updated\nin %.1f seconds." % [duration]
+          "Bundle has been installed\nin %.1f seconds." % [duration]
         else
-          "Bundle can't be updated,\nplease check manually."
+          "Bundle can't be installed,\nplease check manually."
         end
       end
 
@@ -27,7 +27,7 @@ module Guard
         message = guard_message(result, duration)
         image   = guard_image(result)
 
-        ::Guard::Notifier.notify(message, :title => 'Bundle update', :image => image)
+        ::Guard::Notifier.notify(message, :title => 'bundle install', :image => image)
       end
 
     end

--- a/spec/guard/bundler/notifier_spec.rb
+++ b/spec/guard/bundler/notifier_spec.rb
@@ -6,12 +6,12 @@ describe Guard::Bundler::Notifier do
 
   it 'should format success message' do
     message = subject.guard_message(true, 10.1)
-    message.should == "Bundle has been updated\nin 10.1 seconds."
+    message.should == "Bundle has been installed\nin 10.1 seconds."
   end
 
   it 'should format fail message' do
     message = subject.guard_message(false, 10.1)
-    message.should == "Bundle can't be updated,\nplease check manually."
+    message.should == "Bundle can't be installed,\nplease check manually."
   end
 
   it 'should select success image' do
@@ -24,8 +24,8 @@ describe Guard::Bundler::Notifier do
 
   it 'should call Guard::Notifier' do
     ::Guard::Notifier.should_receive(:notify).with(
-      "Bundle has been updated\nin 10.1 seconds.",
-      :title => 'Bundle update',
+      "Bundle has been installed\nin 10.1 seconds.",
+      :title => 'bundle install',
       :image => :success
     )
     subject.notify(true, 10.1)


### PR DESCRIPTION
IMHO it's irritating that the notifications show "Bundle update" in the title and always mention "bundle updated" in the body as well.

This PR changes the notification bodies to "bundle installed" everywhere, and the title to "bundle install". I downcased the first term in the title as well (was "Bundle update") as in my opinion it's closer to a programmer's mind to just see the thing you'd have typed in the terminal to perform the operation.
