### PR TITLE
Remove notification when the bundle is already up to date

### DIFF
--- a/lib/guard/bundler.rb
+++ b/lib/guard/bundler.rb
@@ -44,7 +44,6 @@ module Guard
         @result
       else
         UI.info 'Bundle already up-to-date', :reset => true
-        Notifier.notify('up-to-date', nil)
         true
       end
     end

--- a/spec/guard/bundler_spec.rb
+++ b/spec/guard/bundler_spec.rb
@@ -62,7 +62,7 @@ describe Guard::Bundler do
 
     it 'should call notifier if bundle do not need refresh' do
       subject.stub!(:bundle_need_refresh?).and_return(false)
-      Guard::Bundler::Notifier.should_receive(:notify).with('up-to-date', anything())
+      Guard::Bundler::Notifier.should_not_receive(:notify).with('up-to-date', anything())
       subject.send(:refresh_bundle)
     end
 


### PR DESCRIPTION
Eliminate the minor interruption of notifying the dev when nothing has changed. Leave the UI message in place.
