### PR TITLE
`bundle check` does more than just check the bundle -- it can update Gemfile.lock

### DIFF
--- a/lib/guard/bundler.rb
+++ b/lib/guard/bundler.rb
@@ -34,27 +34,43 @@ module Guard
     private
 
     def refresh_bundle
-      if bundle_need_refresh?
-        ::Guard::UI.info 'Refresh bundle', :reset => true
-        start_at = Time.now
-        ::Bundler.with_clean_env do
-          @result = system("bundle install#{" #{options[:cli]}" if options[:cli]}")
-        end
-        Notifier.notify(@result, Time.now - start_at)
-        @result
+      start_at = Time.now
+      result = bundle_check || bundle_install
+      duration = Time.now - start_at
+      case result
+      when :bundle_already_up_to_date
+        ::Guard::UI.info 'Bundle already up-to-date', :reset => true
+      when :bundle_installed_using_local_gems
+        ::Guard::UI.info 'Bundle installed using local gems', :reset => true
+        Notifier.notify 'bundle_check_install', nil
+      when :bundle_installed
+        ::Guard::UI.info 'Bundle installed', :reset => true
+        Notifier.notify true, duration
       else
-        UI.info 'Bundle already up-to-date', :reset => true
-        Notifier.notify('up-to-date', nil)
-        true
+        ::Guard::UI.info "Bundle can't be installed -- Please check manually", :reset => true
+        Notifier.notify false, nil
       end
+      result
     end
 
-    def bundle_need_refresh?
+    def bundle_check
+      gemfile_lock_mtime = File.exists?('Gemfile.lock') ? File.mtime('Gemfile.lock') : nil
       ::Bundler.with_clean_env do
         `bundle check`
       end
-      $? == 0 ? false : true
+      return false unless $? == 0
+      if gemfile_lock_mtime && gemfile_lock_mtime == File.mtime('Gemfile.lock')
+        :bundle_already_up_to_date
+      else
+        :bundle_installed_using_local_gems
+      end
     end
 
+    def bundle_install
+      ::Bundler.with_clean_env do
+        system("bundle install#{" #{options[:cli]}" if options[:cli]}")
+      end
+      $? == 0 ? :bundle_installed : false
+    end
   end
 end

--- a/lib/guard/bundler/notifier.rb
+++ b/lib/guard/bundler/notifier.rb
@@ -7,6 +7,8 @@ module Guard
         case result
         when 'up-to-date'
           "Bundle already up-to-date"
+        when 'bundle_check_install'
+          "Bundle installed using local gems"
         when true
           "Bundle has been installed\nin %.1f seconds." % [duration]
         else


### PR DESCRIPTION
After a modification to 'Gemfile', guard-bundler would sometimes report 'Bundle already up-to-date' when it in fact the bundle was not up to date. It turns out that the 'bundle check' command updates 'Gemfile.lock' and returns with success when all dependencies can be met by using locally installed gems.

This PR refactors the #bundle_refresh method to handle this additional behavior of the 'bundle check' command. Tests are updated to accomodate these changes.
