### PR TITLE
watch Gemfile.lock too

### DIFF
--- a/lib/guard/bundler/templates/Guardfile
+++ b/lib/guard/bundler/templates/Guardfile
@@ -3,7 +3,7 @@ guard :bundler do
   require 'guard/bundler/verify'
   helper = Guard::Bundler::Verify.new
 
-  files = ['Gemfile']
+  files = ['Gemfile', 'Gemfile.lock']
   files += Dir['*.gemspec'] if files.any? { |f| helper.uses_gemspec?(f) }
 
   # Assume files are symlinked from somewhere


### PR DESCRIPTION
Even the `Gemfile.lock` should be watched to trigger bundle on updates from repo changes