### PR TITLE
Fix compatibility issue with ruby 3.2

### DIFF
--- a/lib/guard/bundler.rb
+++ b/lib/guard/bundler.rb
@@ -54,7 +54,7 @@ module Guard
     end
 
     def bundle_check
-      gemfile_lock_mtime = File.exists?('Gemfile.lock') ? File.mtime('Gemfile.lock') : nil
+      gemfile_lock_mtime = File.exist?('Gemfile.lock') ? File.mtime('Gemfile.lock') : nil
       ::Bundler.with_unbundled_env do
         `bundle check`
       end


### PR DESCRIPTION
As reported in #44 `guard-bundler` doesn't work with ruby 3.2. It fails with error:

```
Guard::Bundler failed to achieve its <start>, exception was:
> [#fb2815b9936d] NoMethodError: undefined method `exists?' for File:Class
```

This PR replaces `File.exists?` with `File.exist?`. `File.exists?` was deprecated in ruby 2.1.0 and was removed in ruby 3.2.0.